### PR TITLE
Fix Matomo tracking snippet

### DIFF
--- a/src/components/Matomo.astro
+++ b/src/components/Matomo.astro
@@ -1,19 +1,15 @@
+<!-- Matomo -->
 <script is:inline>
-  const _paq = (window._paq = window._paq || []);
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
-  (function () {
-    const u = 'https://apps.lib.umn.edu/matomo/';
-    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  (function() {
+    var u="https://apps.lib.umn.edu/matomo/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
     _paq.push(['setSiteId', '48']);
-    const d = document,
-      g = d.createElement('script'),
-      s = d.getElementsByTagName('script')[0];
-    g.async = true;
-    g.src = u + 'matomo.js';
-    s.parentNode.insertBefore(g, s);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
-
-  const track = () => _paq.push(['trackPageView']);
-  document.addEventListener('astro:page-load', track);
 </script>
+<!-- End Matomo Code -->


### PR DESCRIPTION
Restores the official Matomo code block with var _paq so matomo.js can initialize correctly and send pageview requests.